### PR TITLE
Split Log4j plugins and Tomcat components

### DIFF
--- a/log4j-tomcat-juli/pom.xml
+++ b/log4j-tomcat-juli/pom.xml
@@ -21,13 +21,18 @@
     <artifactId>log4j-plugins-parent</artifactId>
     <version>3.0.0-SNAPSHOT</version>
   </parent>
-  <artifactId>log4j-tomcat</artifactId>
-  <name>Tomcat components for Log4j</name>
-  <description>Tomcat 8.5.x/9.x/10.x components to improve support for Log4j API.</description>
+  <artifactId>log4j-tomcat-log4j</artifactId>
+  <name>Log4j Core plugins for Tomcat</name>
+  <description>Log4j Core plugins that improve logging support on Tomcat</description>
   <dependencies>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.apache.tomcat</groupId>
-      <artifactId>tomcat-catalina</artifactId>
+      <artifactId>tomcat-juli</artifactId>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -43,16 +48,6 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/log4j-tomcat-juli/src/main/java/eu/copernik/log4j/tomcat/juli/TomcatLookup.java
+++ b/log4j-tomcat-juli/src/main/java/eu/copernik/log4j/tomcat/juli/TomcatLookup.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.copernik.log4j.tomcat;
+package eu.copernik.log4j.tomcat.juli;
 
 import org.apache.juli.WebappProperties;
 import org.apache.logging.log4j.core.LogEvent;

--- a/log4j-tomcat-juli/src/test/java/eu/copernik/log4j/tomcat/juli/TomcatLookupTest.java
+++ b/log4j-tomcat-juli/src/test/java/eu/copernik/log4j/tomcat/juli/TomcatLookupTest.java
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package eu.copernik.log4j.tomcat;
+package eu.copernik.log4j.tomcat.juli;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.mock;

--- a/log4j-tomcat/src/test/java/eu/copernik/log4j/tomcat/Log4jWebappClassLoaderTest.java
+++ b/log4j-tomcat/src/test/java/eu/copernik/log4j/tomcat/Log4jWebappClassLoaderTest.java
@@ -97,8 +97,8 @@ public class Log4jWebappClassLoaderTest {
         // TODO: loading LoggerContext fails
         // Arguments.of(org.apache.logging.log4j.core.LoggerContext.class, false,
         // false),
-        Arguments.of(Configuration.class, false, false),
-        Arguments.of(TomcatLookup.class, true, true));
+        Arguments.of(Configuration.class, false, false));
+    // Arguments.of(TomcatLookup.class, true, true));
   }
 
   @RepeatedTest(100)

--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,7 @@
 
   <modules>
     <module>log4j-tomcat</module>
+    <module>log4j-tomcat-juli</module>
   </modules>
 
   <scm>


### PR DESCRIPTION
Log4j Core plugins and Tomcat components need to be in different classloaders:

 * Log4j core plugins should be in the system classloader,
 * Tomcat components must be in the server/common classloader.