### PR TITLE
Add Tomcat-specific data to ThreadContext

### DIFF
--- a/log4j-tomcat-env/pom.xml
+++ b/log4j-tomcat-env/pom.xml
@@ -38,6 +38,11 @@
     </dependency>
 
     <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>biz.aQute.bnd.annotation</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
     </dependency>

--- a/log4j-tomcat-env/src/main/java/eu/copernik/log4j/tomcat/env/TomcatContextDataProvider.java
+++ b/log4j-tomcat-env/src/main/java/eu/copernik/log4j/tomcat/env/TomcatContextDataProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright © 2023 Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.copernik.log4j.tomcat.env;
+
+import aQute.bnd.annotation.Resolution;
+import aQute.bnd.annotation.spi.ServiceProvider;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.juli.WebappProperties;
+import org.apache.logging.log4j.core.util.ContextDataProvider;
+import org.apache.logging.log4j.util.SortedArrayStringMap;
+import org.apache.logging.log4j.util.StringMap;
+
+@ServiceProvider(value = ContextDataProvider.class, resolution = Resolution.OPTIONAL)
+public class TomcatContextDataProvider implements ContextDataProvider {
+
+    private final ConcurrentMap<Integer, Map<String, String>> mapCache = new ConcurrentHashMap<>();
+    private final ConcurrentMap<Integer, StringMap> stringMapCache = new ConcurrentHashMap<>();
+
+    @Override
+    public Map<String, String> supplyContextData() {
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final int hashCode = System.identityHashCode(tccl);
+        return mapCache.computeIfAbsent(hashCode, __ -> {
+            final HashMap<String, String> map = new HashMap<>(3);
+            if (tccl instanceof WebappProperties) {
+                final WebappProperties props = (WebappProperties) tccl;
+                map.put(TomcatLookup.CONTEXT_NAME, props.getWebappName());
+                map.put(TomcatLookup.ENGINE_NAME, props.getServiceName());
+                map.put(TomcatLookup.HOST_NAME, props.getHostName());
+            }
+            return Collections.unmodifiableMap(map);
+        });
+    }
+
+    @Override
+    public StringMap supplyStringMap() {
+        final ClassLoader tccl = Thread.currentThread().getContextClassLoader();
+        final int hashCode = System.identityHashCode(tccl);
+        return stringMapCache.computeIfAbsent(hashCode, __ -> {
+            final StringMap map = new SortedArrayStringMap(3);
+            if (tccl instanceof WebappProperties) {
+                final WebappProperties props = (WebappProperties) tccl;
+                map.putValue(TomcatLookup.CONTEXT_NAME, props.getWebappName());
+                map.putValue(TomcatLookup.ENGINE_NAME, props.getServiceName());
+                map.putValue(TomcatLookup.HOST_NAME, props.getHostName());
+            }
+            map.freeze();
+            return map;
+        });
+    }
+}

--- a/log4j-tomcat-env/src/test/java/eu/copernik/log4j/tomcat/env/TomcatContextDataProviderTest.java
+++ b/log4j-tomcat-env/src/test/java/eu/copernik/log4j/tomcat/env/TomcatContextDataProviderTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright © 2024 Piotr P. Karwasz
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package eu.copernik.log4j.tomcat.env;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import java.util.function.BiFunction;
+import org.apache.logging.log4j.util.StringMap;
+import org.junit.jupiter.api.Test;
+
+class TomcatContextDataProviderTest extends AbstractClassLoaderTest {
+
+    @Test
+    void supplyContextData() {
+        assertData(new TomcatContextDataProvider().supplyContextData(), Map::get);
+    }
+
+    @Test
+    void supplyStringMap() {
+        assertData(new TomcatContextDataProvider().supplyStringMap(), StringMap::getValue);
+    }
+
+    private static <T> void assertData(final T map, final BiFunction<T, ? super String, String> getValue) {
+        assertThat(getValue.apply(map, "engine.name")).isEqualTo(ENGINE_NAME);
+        assertThat(getValue.apply(map, "host.name")).isEqualTo(HOST_NAME);
+        assertThat(getValue.apply(map, "context.name")).isEqualTo(CONTEXT_NAME);
+    }
+}

--- a/log4j-tomcat-env/src/test/java/eu/copernik/log4j/tomcat/env/TomcatLookupTest.java
+++ b/log4j-tomcat-env/src/test/java/eu/copernik/log4j/tomcat/env/TomcatLookupTest.java
@@ -23,13 +23,13 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
-public class TomcatLookupTest extends AbstractClassLoaderTest {
+class TomcatLookupTest extends AbstractClassLoaderTest {
 
     private static final String ENGINE_LOGGERNAME = "org.apache.catalina.core.ContainerBase.[" + ENGINE_NAME + "]";
     private static final String HOST_LOGGERNAME = ENGINE_LOGGERNAME + ".[" + HOST_NAME + "]";
     private static final String CONTEXT_LOGGERNAME = HOST_LOGGERNAME + ".[" + CONTEXT_NAME + "]";
 
-    static Stream<Arguments> data() {
+    static Stream<Arguments> lookupWorksProperly() {
         return Stream.of(
                 Arguments.of("classloader.serviceName", ENGINE_NAME),
                 Arguments.of("engine.name", ENGINE_NAME),
@@ -44,8 +44,8 @@ public class TomcatLookupTest extends AbstractClassLoaderTest {
     }
 
     @ParameterizedTest
-    @MethodSource("data")
-    public void lookupWorksProperly(final String key, final String value) {
+    @MethodSource
+    void lookupWorksProperly(final String key, final String value) {
         final StrLookup lookup = new TomcatLookup();
         assertThat(lookup.lookup(key)).isEqualTo(value);
     }

--- a/src/changelog/.3.x.x/103_context_data_provider.xml
+++ b/src/changelog/.3.x.x/103_context_data_provider.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns="http://logging.apache.org/log4j/changelog"
+       xsi:schemaLocation="http://logging.apache.org/log4j/changelog https://logging.apache.org/log4j/changelog-0.1.3.xsd"
+       type="changed">
+  <issue id="103" link="https://github.com/copernik-eu/log4j-plugins/issues/103"/>
+  <description format="asciidoc">
+    Add a context data provider to fill the "engine.name", "host.name" and "context.name" context entries.
+  </description>
+</entry>


### PR DESCRIPTION
This adds a `ContextDataProvider` that automatically fills the following context data:

 * "engine.name": the name of the Tomcat engine,
 * "host.name": the name of the Tomcat host,
 * "context.name": the name of the Tomcat context.

Closes #103.